### PR TITLE
Provide implementation of 'table.foreach' in tests

### DIFF
--- a/test/some_functions.lua
+++ b/test/some_functions.lua
@@ -123,6 +123,13 @@ function capitalize(s)
 	return s:sub(1, 1):upper() .. s:sub(2)
 end
 
+function table.foreach(t, fun)
+	for k, v in pairs(t) do
+		local result = fun(k, v)
+		if result then return result end
+	end
+end
+
 function element(s, t)
 	local function lookup(k, v)
 		return v == s and k or nil


### PR DESCRIPTION
`table.foreach` is [deprecated in Lua 5.1](http://www.lua.org/manual/5.1/manual.html#7.2) and deleted in Lua 5.2. An explicit implementation of the function must be provided to be able to pass the tests using Lua 5.2.
